### PR TITLE
Build/ Update ember-feature-flags to 6.0.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2018,
     sourceType: "module"
   },
   plugins: ["ember"],
@@ -31,8 +31,7 @@ module.exports = {
         "tests/dummy/app/**"
       ],
       parserOptions: {
-        sourceType: "script",
-        ecmaVersion: 2015
+        sourceType: "script"
       },
       env: {
         browser: false,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.11.1",
     "ember-cli-htmlbars": "^4.0.0",
-    "ember-feature-flags": "^5.0.0",
+    "ember-feature-flags": "^6.0.0",
     "ember-get-config": "^0.2.4",
     "ember-local-storage": "^1.4.1",
     "ember-truth-helpers": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3828,11 +3828,12 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-feature-flags@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ember-feature-flags/-/ember-feature-flags-5.0.0.tgz#630d2876f5341b456db89996f35c0b109a0e27ec"
+ember-feature-flags@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ember-feature-flags/-/ember-feature-flags-6.0.0.tgz#3509984b575798dda337c3f18d309a8d5aca0ad8"
+  integrity sha512-CcKpQ0NI/AMkYcP/4obqfDrzFlLqFngabFUfmAlQNnCic5cz51nlLY9MzYRtbop0+1iyegM4XHJFE4Awlji/1g==
   dependencies:
-    ember-cli-babel "^6.6.0"
+    ember-cli-babel "^7.11.1"
 
 ember-get-config@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
## Build 
### [`ember-feature-flags`](https://github.com/kategengler/ember-feature-flags) 6.0.0 (#43) 
Breaking changes don't impact this addon directly as we are already in a later version of Ember/Node. 