### PR TITLE
Build/ Release 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-feature-controls",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Hot plug your features.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
## Breaking
### `ember-feature-flags` 6.X (#43) 
See [commit stack](https://github.com/kategengler/ember-feature-flags/commits/master).

## Config
### @dependabot (#40)
Dependabot is now configured on this addon. 

### Node 10 on CI (#40)
NodeJS version has been set to 10 on CI config

## Build 
### @dependabot bumps
Bumps [lodash.defaultsdeep](https://github.com/lodash/lodash) from 4.6.0 to 4.6.1. (#24) 
Bumps [merge](https://github.com/yeikos/js.merge) from 1.2.0 to 1.2.1. (#25) 
Bumps [js-yaml](https://github.com/nodeca/js-yaml) from 3.12.0 to 3.13.1. (#26) 
Bumps [mixin-deep](https://github.com/jonschlinkert/mixin-deep) from 1.3.1 to 1.3.2. (#27) 
Bumps [underscore.string](https://github.com/epeli/underscore.string) from 3.3.4 to 3.3.5. (#28) 
Bumps [lodash.mergewith](https://github.com/lodash/lodash) from 4.6.1 to 4.6.2. (#29) 
Bumps [tar](https://github.com/npm/node-tar) from 2.2.1 to 2.2.2. (#31) 
Bumps [handlebars](https://github.com/wycats/handlebars.js) from 4.0.12 to 4.5.3. (#33) 
Bumps [websocket-extensions](https://github.com/faye/websocket-extensions-node) from 0.1.3 to 0.1.4. (#37) 
Bumps [jquery](https://github.com/jquery/jquery) from 3.4.1 to 3.5.1. (#39) 
Bumps [lodash](https://github.com/lodash/lodash) from 4.17.11 to 4.17.19. (#41)
Bumps [dot-prop](https://github.com/sindresorhus/dot-prop) from 5.1.0 to 5.2.0. (#42)  

### [`ember-feature-flags`](https://github.com/kategengler/ember-feature-flags) 6.0.0 (#43) 
Breaking changes don't impact this addon directly as we are already in a later version of Ember/Node. 

### Ember 3.13

#### 3.8 (#22) 
- Ember 3.8 update
- Add link to CONTRIBUTING.md in the README

#### 3.13 (#23)
 - Ember 3.13 update
 - ends suppor for Ember 2.18
 - minimum Ember version 3.4
 - minimum node version 8+ or 10+


