### PR TITLE
build: release v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-feature-controls",
   "description": "Hot plug your features.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": {
     "name": "PeopleDoc",


### PR DESCRIPTION
## Breaking changes

#### Upgrade to ember 3.20 (#57)

Drop support for Node.js version 8.

#### Update to ember 3.24 (#126)

Drop support for Node.js version below v10.
Drop support for Ember.js versions below v3.16.

#### Set requirement for Node.js to version 12 (#139)

#### Upgrade to ember 3.28 (#153)


## Build

#### Bump `acorn` from 6.3.0 to 6.4.1 (#35)
#### Bump `http-proxy` from 1.17.0 to 1.18.1 (#53)
#### Bump `lodash.merge` from 4.6.1 to 4.6.2 (#51)
#### Bump `node-sass` from 4.9.3 to 4.14.1 (#52)
#### Bump `ember-cli-github-pages` from 0.2.1 to 0.2.2 (#59)
#### Bump `eslint-plugin-ember` from 8.14.0 to 9.3.0 (#58)
#### Bump `ember-milligram` from 0.2.0 to 0.3.0 (#61)
#### Bump `ember-test-selectors` from 1.0.0 to 5.0.0 (#60)
#### Bump `eslint` from 7.11.0 to 7.12.1 (#63)
#### Bump `ember-truth-helpers` from 2.1.0 to 3.0.0 (#62)
#### Bump `ember-auto-import` from 1.6.0 to 1.7.0 (#64)
#### Bump `ember-source-channel-url` from 2.0.1 to 3.0.0 (#65)
#### Bump `ember-load-initializers` from 2.1.1 to 2.1.2 (#66)
#### Bump `eslint` from 7.12.1 to 7.14.0 (#68)
#### Bump `@ember/optional-features` from 1.3.0 to 2.0.0 (#69)
#### Bump `qunit-dom` from 1.5.0 to 1.6.0 (#71)
#### Bump `sass` from 1.27.0 to 1.29.0 (#72)
#### Bump `ember-auto-import` from 1.7.0 to 1.8.0 (#75)
#### Bump `ini` from 1.3.5 to 1.3.7 (#76)
#### Bump `eslint` from 7.14.0 to 7.15.0 (#77)
#### Bump `@glimmer/component` from 1.0.2 to 1.0.3 (#78)
#### Bump `sass` from 1.29.0 to 1.30.0 (#79)
#### Bump `ember-template-lint` from 2.14.0 to 2.15.0 (#80)
#### Bump `@glimmer/tracking` from 1.0.2 to 1.0.3 (#82)
#### Bump `ember-auto-import` from 1.8.0 to 1.10.1 (#84)
#### Bump `sass` from 1.30.0 to 1.32.2 (#85)
#### Bump `ember-template-lint` from 2.15.0 to 2.16.0 (#86)
#### Bump `socket.io` from 2.3.0 to 2.4.1 (#88)
#### Bump `ember-source` from 3.20.5 to 3.24.1 (#89)
#### Bump `eslint` from 7.15.0 to 7.18.0 (#90)
#### Bump `ember-cli-babel` from 7.23.0 to 7.23.1 (#91)
#### Bump `sass` from 1.32.2 to 1.32.5 (#93)
#### Bump `sass` from 1.32.5 to 1.32.6 (#94)
#### Bump `ember-template-lint` from 2.16.0 to 2.18.1 (#95)
#### Bump `ember-cli-htmlbars` from 5.3.1 to 5.3.2 (#97)
#### Bump `ember-template-lint` from 2.18.1 to 2.19.0 (#98)
#### Bump `ember-cli-htmlbars` from 5.3.2 to 5.6.1 (#99)
#### Bump `ember-cli-htmlbars` from 5.6.1 to 5.6.2 (#100)
#### Bump `@glimmer/component` from 1.0.3 to 1.0.4 (#101)
#### Bump `elliptic` from 6.5.3 to 6.5.4 (#103)
#### Bump `@glimmer/tracking` from 1.0.3 to 1.0.4 (#105)
#### Bump `ember-cli-htmlbars` from 5.6.2 to 5.7.1 (#107)
#### Bump `ember-auto-import` from 1.10.1 to 1.11.2 (#108)
#### Bump `ember-cli-babel` from 7.23.1 to 7.26.3 (#109)
#### Bump `sass` from 1.32.6 to 1.32.8 (#110)
#### Bump `ember-template-lint` from 3.1.1 to 3.2.0 (#113)
#### Bump `ember-source` from 3.24.1 to 3.26.1 (#114)
#### Bump `eslint` from 7.18.0 to 7.24.0 (#115)
#### Bump `ssri` from 6.0.1 to 6.0.2 (#117)
#### Bump `sass` from 1.32.8 to 1.32.10 (#116)
#### Bump `sass` from 1.32.10 to 1.32.11 (#118)
#### Bump `underscore` from 1.11.0 to 1.13.1 (#121)
#### Bump `handlebars` from 4.7.6 to 4.7.7 (#122)
#### Bump `hosted-git-info` from 2.8.8 to 2.8.9 (#123)
#### Bump `ws` from 7.4.5 to 7.4.6 (#125)
#### Bump `qunit` from 2.15.0 to 2.16.0 (#130)
#### Bump `@ember/test-helpers` from 2.2.6 to 2.2.8 (#129)
#### Bump `ember-test-selectors` from 5.3.0 to 5.5.0 (#134)
#### Bump `prettier` from 2.3.0 to 2.3.2 (#133)
#### Bump `ember-template-lint` from 2.21.0 to 3.6.0 (#142)
#### Bump `ember-test-selectors` from 5.5.0 to 6.0.0 (#143)
#### Bump `prettier` from 2.3.2 to 2.4.0 (#144)
#### Bump `eslint-plugin-ember` from 10.5.0 to 10.5.4 (#145)
#### Bump `eslint-plugin-prettier` from 3.4.0 to 3.4.1 (#146)
#### Bump `qunit-dom` from 1.6.0 to 2.0.0 (#147)
#### Bump `tmpl` from 1.0.4 to 1.0.5 (#148)
#### Bump `@ember/test-helpers` from 2.2.8 to 2.4.2 (#149)
#### Bump `ember-resolver` from 8.0.2 to 8.0.3 (#150)
#### Bump `ember-auto-import` from 1.11.3 to 2.2.0
#### Bump `ember-maybe-import-regenerator` from 0.1.6 to 1.0.0 (#154)
#### Bump `@embroider/test-setup` from 0.43.5 to 0.47.0 (#155)
#### Bump `eslint-plugin-qunit` from 6.2.0 to 7.0.0 (#157)
#### Bump `eslint-plugin-ember` from 10.5.5 to 10.5.7 (#158)
#### Bump `ember-cli-htmlbars` from 5.7.1 to 6.0.0 (#162)
#### Bump `ember-template-lint` from 3.9.0 to 3.11.0 (#163)

#### Update dependencies for security issues (#32)

#### Reset whole project as of v3.20.2 (#104)

#### Upgrade `ember-template-lint@3.1.1` (#104)

#### Rebuild file `yarn.lock` (#120)

And fix a bunch of vulnerabilities.

#### Install `@embroider/test-setup` (#139)

#### Update `ember-auto-import` from 1.11.3 to 2.2.0 (#152)

Also add `webpack` version 5 to dev dependencies (requirement for `ember-auto-import` v2).

#### Update `@embroider/test-setup` to v0.47.1 (#160)

#### Disable Embroider's compatibility adapter for `ember-get-config` (#160)

See the dedicated commit for extensive details about these changes.

#### Deduplicate packages (#160)

See https://github.com/atlassian/yarn-deduplicate.


## Chores

#### Update lint config of HBS files (#104)

#### Disable lint rule `no-bare-strings` in HBS (#104)

#### Set @peopledoc/tribe-js as code owner (#161)

#### Refine information in package.json (#164)

#### Add contributors to README (#166)


## CI

#### Move to GitHub Actions (#131)

Use Github Actions instead of TravisCI.

#### Use Node.js version 12 (#139)

#### Remove Ember 3.16 LTS from `ember-try` testing (#139)

#### Remove `ember-beta` scenario (#139)

#### Add Ember 3.24 LTS to `ember-try` testing (#139)

#### Reuse organisation's workflow to run lint & tests (#160)

This change also activates the tests for Embroider.

#### Reuse organisation's workflow to run tag & publish (#160)


## Documentation

#### Add CI badge in the README (#132)

#### Set requirement for Node.js to version 12 (#139)


## Fixes

####  Use `ember-local-storage` for both read & write FF to prevent issue when `ember-local-storage` options differents from default (#112)

This fix #111


## Refactor

#### Fix issues due to new lint config of HBS files (#104)

- Remove final newline in HBS files
- Remove deprecated use of `{{action}}`